### PR TITLE
Add hooks for resolving named and tagged bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ class AppOrModuleRoot extends React.Component {
 const foo = useInjection(Foo);
 ```
 * very similar to [React.useContext](https://reactjs.org/docs/hooks-reference.html#usecontext) hook, resolves dependency by id
+* To resolve named bindings, use the `useNamedInjection` hook; for tagged bindings, use the `useTaggedInjection` hook.
 
 ### useOptionalInjection
 

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -89,3 +89,25 @@ export function useAllInjections<T>(serviceId: interfaces.ServiceIdentifier<T>):
         container => container.getAll(serviceId)
     );
 }
+
+/**
+ * uses container.getNamed(serviceIdentifier, named)
+ * https://github.com/inversify/InversifyJS/blob/master/wiki/container_api.md#containergetnamedtserviceidentifier-interfacesserviceidentifiert-named-string--number--symbol-t
+ * https://github.com/inversify/InversifyJS/blob/master/wiki/named_bindings.md
+ */
+export function useNamedInjection<T>(serviceId: interfaces.ServiceIdentifier<T>, named: string | number | symbol): T {
+    return useContainer(
+        container => container.getNamed<T>(serviceId, named)
+    );
+}
+
+/**
+ * uses container.getTagged(serviceIdentifier, key, value)
+ * https://github.com/inversify/InversifyJS/blob/master/wiki/container_api.md#containergettaggedtserviceidentifier-interfacesserviceidentifiert-key-string--number--symbol-value-unknown-t
+ * https://github.com/inversify/InversifyJS/blob/master/wiki/tagged_bindings.md
+ */
+export function useTaggedInjection<T>(serviceId: interfaces.ServiceIdentifier<T>, key: string | number | symbol, value: unknown): T {
+    return useContainer(
+        container => container.getTagged<T>(serviceId, key, value)
+    );
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,4 +5,6 @@ export {
     useContainer,
     useInjection,
     useOptionalInjection,
+    useNamedInjection,
+    useTaggedInjection,
 } from './hooks';


### PR DESCRIPTION
Lovely work with this library, everyone!
I was missing a convinient way to resolve my named binding so I added `useNamedInjection` and while I was at it `useTaggedInjection` has quite a similar usage.

Consider merging these changes.
I am open to feedback to improve the code to your liking.